### PR TITLE
fix: headless mode

### DIFF
--- a/lua/bufresize.lua
+++ b/lua/bufresize.lua
@@ -15,6 +15,9 @@ local register = function()
 		return
 	end
 	local ui = vim.api.nvim_list_uis()[1]
+	if ui == nil then
+		return
+	end
 	vim_size.width = ui.width
 	vim_size.height = ui.height
 	win_size = {}


### PR DESCRIPTION
When running in headless mode with: `nvim --headless` we get the following error:

```
Error detected while processing BufWinEnter Autocommands for "*":
E5108: Error executing lua .../site/pack/packer/start/bufresize.nvim/lua/bufresize.lua:22: attempt to index local 'ui' (a nil value)
stack traceback:
	.../site/pack/packer/start/bufresize.nvim/lua/bufresize.lua:22: in function 'register'
	[string ":lua"]:1: in main chunk
Press ENTER or type command to continue
```

I have made a quick fix by checking if `ui` is nil and returning from register. There may be a more elegant solution.